### PR TITLE
Fixed issue with the way that ClearTerm worked

### DIFF
--- a/src/term.cpp
+++ b/src/term.cpp
@@ -404,7 +404,7 @@ void Term::ClearTerm(void) {
     for (r = 0; r < GetHeight(); r++) {
         SetCursorRow(r);
         for (c = 0; c < GetWidth(); c++) {
-            Print(" ");
+            PutChar(' ');
         }
     }
 


### PR DESCRIPTION
ClearTerm didn't keep track of the change to the cursor position so when it tried to reset to the previous position it failed to do so. Just changed the print to a PutChar so it would.